### PR TITLE
fix(devtool): update interface names

### DIFF
--- a/packages/devtool/src/index.ts
+++ b/packages/devtool/src/index.ts
@@ -33,7 +33,7 @@ const logStateAction = (action: Action<unknown>) => {
     params: filterParams(action.payload),
   }
 
-  STATE[namespace] = (action as any).state.getState()
+  STATE[namespace] = (action as any).store.getState()
 
   if (!(action.type as string)?.endsWith?.(INIT_ACTION_TYPE)) {
     devtool.send(_action, STATE)


### PR DESCRIPTION
`devtool`中`action`引用的`state`应该更改成`store`