### PR TITLE
feat(ssr): support match fn

### DIFF
--- a/configs/jest.config.js
+++ b/configs/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
       '@swc-node/jest',
       // configuration
       {
-        target: 'es2019',
+        target: 'es2020',
         experimentalDecorators: true,
         emitDecoratorMetadata: true,
         react: {

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -30,6 +30,7 @@
     "@sigi/core": "^2.10.8",
     "@sigi/di": "^2.10.2",
     "@sigi/types": "^2.10.2",
+    "path-to-regexp": "^6.2.0",
     "serialize-javascript": "^5.0.1",
     "tslib": "^2.2.0"
   },

--- a/packages/ssr/src/__tests__/match.spec.ts
+++ b/packages/ssr/src/__tests__/match.spec.ts
@@ -1,0 +1,42 @@
+import { match } from '../match'
+import { SKIP_SYMBOL } from '../run'
+
+const CONTEXT = {
+  request: {
+    path: '/users/1111',
+  },
+}
+
+describe('Match function test', () => {
+  it('should return skip symbol if not matched', () => {
+    const payloadGetter = match(
+      ['/user/me'],
+      (ctx: typeof CONTEXT) => ctx.request.path,
+    )(() => {
+      return 1
+    })
+    // @ts-expect-error
+    expect(payloadGetter(CONTEXT)).toBe(SKIP_SYMBOL)
+  })
+
+  it('should return skip symbol if request factory return falsy value', () => {
+    const payloadGetter = match(
+      ['/user/me'],
+      (_ctx: typeof CONTEXT) => '',
+    )(() => {
+      return 1
+    })
+    // @ts-expect-error
+    expect(payloadGetter(CONTEXT)).toBe(SKIP_SYMBOL)
+  })
+
+  it('should into matched router', () => {
+    const payloadGetter = match(
+      ['/users/:id'],
+      (ctx: typeof CONTEXT) => ctx.request.path,
+    )(() => {
+      return 1
+    })
+    expect(payloadGetter(CONTEXT, SKIP_SYMBOL)).toBe(1)
+  })
+})

--- a/packages/ssr/src/index.ts
+++ b/packages/ssr/src/index.ts
@@ -1,1 +1,2 @@
 export { runSSREffects as emitSSREffects, ModuleMeta } from './run'
+export { match } from './match'

--- a/packages/ssr/src/match.ts
+++ b/packages/ssr/src/match.ts
@@ -1,0 +1,15 @@
+import { match as matchPath } from 'path-to-regexp'
+
+import { SKIP_SYMBOL } from './run'
+
+export function match<Ctx>(routers: string[], pathFactory: (ctx: Ctx) => string) {
+  return <T>(payloadGetter: (ctx: Ctx, skip: symbol) => T | Promise<T>) => {
+    return function payloadGetterWithMatch(ctx: Ctx, skip: symbol) {
+      const requestPath = pathFactory(ctx)
+      if (requestPath && routers.some((router) => matchPath(router)(requestPath))) {
+        return payloadGetter(ctx, skip)
+      }
+      return SKIP_SYMBOL
+    }
+  }
+}

--- a/packages/ssr/src/run.ts
+++ b/packages/ssr/src/run.ts
@@ -6,7 +6,7 @@ import { StateToPersist } from './state-to-persist'
 
 export type ModuleMeta = ConstructorOf<EffectModule<any>>
 
-const SKIP_SYMBOL = Symbol('skip-symbol')
+export const SKIP_SYMBOL = Symbol('skip-symbol')
 
 /**
  * Run all `@Effect({ ssr: true })` decorated effects of given modules and extract latest states.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5389,6 +5389,7 @@ minipass-fetch@^1.3.0, minipass-fetch@^1.3.2:
   resolved "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.3.tgz#34c7cea038c817a8658461bf35174551dce17a0a"
   integrity sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==
   dependencies:
+    encoding "^0.1.12"
     minipass "^3.1.0"
     minipass-sized "^1.0.3"
     minizlib "^2.0.0"
@@ -6129,6 +6130,11 @@ path-to-regexp@^1.7.0:
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
```ts
@Effect({
  payloadGetter: match(
    ['/users/:id'],
    (ctx: HttpContext) => ctx.request.path,
  )((ctx) => {
    return ctx.request.path.length
  }),
})
setNameWithFailure(payload$: Observable<number>): Observable<Action> {
  return payload$.pipe(mergeMap((l) => of(this.getActions().setName(`length: ${l}`), this.terminate())))
}
```