### PR TITLE
Fix use stale dep in selector of useModuleState

### DIFF
--- a/packages/react/src/__tests__/react.spec.tsx
+++ b/packages/react/src/__tests__/react.spec.tsx
@@ -68,7 +68,7 @@ describe('React components test', () => {
       selector: (state) => state.count + localCount,
       dependencies: [localCount],
     })
-    spy()
+    spy(state)
     stub.callsFake(() => {
       setLocalCount(localCount + 1)
     })
@@ -82,12 +82,15 @@ describe('React components test', () => {
   it('should render once while initial rendering', () => {
     create(<TestComponent />)
     expect(spy.callCount).toBe(1)
+    expect(spy.getCall(0).calledWith(0)).toBe(true)
   })
 
   it('should render three times while change local state which in dependencies list', () => {
     const reactNode = create(<TestComponent />)
     act(() => stub())
-    expect(spy.callCount).toBe(3)
+    expect(spy.callCount).toBe(2)
+    expect(spy.getCall(0).calledWith(0)).toBe(true)
+    expect(spy.getCall(1).calledWith(1)).toBe(true)
     expect(reactNode).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
先看下这个 test case 是否符合预期，原来的渲染3次 感觉有点多余， 依赖的dep已经更新， 但是useModuleState 会导致拿到陈旧的state